### PR TITLE
add apns-unique-id to Response object

### DIFF
--- a/client.go
+++ b/client.go
@@ -192,6 +192,7 @@ func (c *Client) PushWithContext(ctx Context, n *Notification) (*Response, error
 	r := &Response{}
 	r.StatusCode = response.StatusCode
 	r.ApnsID = response.Header.Get("apns-id")
+	r.ApnsUniqueID = response.Header.Get("apns-unique-id")
 
 	decoder := json.NewDecoder(response.Body)
 	if err := decoder.Decode(r); err != nil && err != io.EOF {

--- a/client_test.go
+++ b/client_test.go
@@ -199,9 +199,11 @@ func TestClientPushWithContextWithTimeout(t *testing.T) {
 func TestClientPushWithContext(t *testing.T) {
 	n := mockNotification()
 	var apnsID = "02ABC856-EF8D-4E49-8F15-7B8A61D978D6"
+	var apnsUniqueID = "FA651524-D6DE-455F-B230-3AD5E2295E60"
 	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		w.Header().Set("Content-Type", "application/json; charset=utf-8")
 		w.Header().Set("apns-id", apnsID)
+		w.Header().Set("apns-unique-id", apnsUniqueID)
 		w.WriteHeader(http.StatusOK)
 	}))
 	defer server.Close()
@@ -209,6 +211,7 @@ func TestClientPushWithContext(t *testing.T) {
 	res, err := mockClient(server.URL).PushWithContext(context.Background(), n)
 	assert.Nil(t, err)
 	assert.Equal(t, res.ApnsID, apnsID)
+	assert.Equal(t, res.ApnsUniqueID, apnsUniqueID)
 }
 
 func TestClientPushWithNilContext(t *testing.T) {

--- a/response.go
+++ b/response.go
@@ -129,6 +129,11 @@ type Response struct {
 	// Notification, this will be a new unique UUID which has been created by APNs.
 	ApnsID string
 
+	// The APNs ApnsUniqueID value from the response "Apns-Unique-Id" header.
+	// This is set in Development mode and used to track status in the
+	// Apple Developer Push Notification Test Console.
+	ApnsUniqueID string
+
 	// If the value of StatusCode is 410, this is the last time at which APNs
 	// confirmed that the device token was no longer valid for the topic.
 	Timestamp Time


### PR DESCRIPTION
The APNs ApnsUniqueID value from the response "Apns-Unique-Id" header. This is set in Development mode and used to track status in the Apple Developer Push Notification Test Console.